### PR TITLE
Fixed skipping on pause bug

### DIFF
--- a/spotify/spotifycontroller.go
+++ b/spotify/spotifycontroller.go
@@ -51,7 +51,7 @@ type Status struct {
 	} `json:"context"`
 	PlayingPosition float64 `json:"playing_position"`
 	ServerTime int `json:"server_time"`
-	Volume int `json:"volume"`
+	Volume float64 `json:"volume"`
 	Online bool `json:"online"`
 	OpenGraphState struct {
 		PrivateSession bool `json:"private_session"`


### PR DESCRIPTION
If spotify volume is not on full (100) or another integer value, the status is unable to be parsed, leading to userPaused not being set, meaning the next song in queue is skipped.